### PR TITLE
drivers: gpio: Create a GPIO fake driver

### DIFF
--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -2,3 +2,4 @@
 
 add_subdirectory_ifdef(CONFIG_LIGHT light)
 add_subdirectory_ifdef(CONFIG_SENSOR sensor)
+add_subdirectory_ifdef(CONFIG_GPIO gpio)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,2 +1,3 @@
 rsource "light/Kconfig"
 rsource "sensor/Kconfig"
+rsource "gpio/Kconfig"

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources_ifdef(CONFIG_GPIO_FAKE gpio_fake.c)

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -1,0 +1,3 @@
+config GPIO_FAKE
+    bool "Fake GPIO controller"
+    depends on DT_HAS_ZEPHYR_GPIO_FAKE_ENABLED

--- a/drivers/gpio/gpio_fake.c
+++ b/drivers/gpio/gpio_fake.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 Alexandre Bailon
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT zephyr_gpio_fake
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_fake.h>
+
+#include <zephyr/fff.h>
+
+#ifdef CONFIG_ZTEST
+#include <zephyr/ztest.h>
+#endif /* CONFIG_ZTEST */
+
+struct gpio_fake_config {
+	gpio_port_pins_t port_pin_mask;
+};
+
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_pin_configure, const struct device *, gpio_pin_t,
+		       gpio_flags_t);
+#ifdef CONFIG_GPIO_GET_CONFIG
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_pin_get_config, const struct device *, gpio_pin_t,
+		       gpio_flags_t *);
+#endif
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_get_raw, const struct device *, gpio_port_value_t *);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_set_masked_raw, const struct device *, gpio_port_pins_t,
+		       gpio_port_value_t);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_set_bits_raw, const struct device *, gpio_port_pins_t);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_clear_bits_raw, const struct device *, gpio_port_pins_t);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_toggle_bits, const struct device *, gpio_port_pins_t);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_pin_interrupt_configure, const struct device *, gpio_pin_t,
+		       enum gpio_int_mode, enum gpio_int_trig);
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_manage_callback, const struct device *,
+		       struct gpio_callback *, bool);
+DEFINE_FAKE_VALUE_FUNC(uint32_t, gpio_fake_get_pending_int, const struct device *);
+#ifdef CONFIG_GPIO_GET_DIRECTION
+DEFINE_FAKE_VALUE_FUNC(int, gpio_fake_port_get_direction, gpio_port_pins_t, gpio_port_pins_t *,
+		       gpio_port_pins_t *);
+#endif
+
+#ifdef CONFIG_ZTEST
+static void gpio_fake_reset_rule_before(const struct ztest_unit_test *test, void *fixture)
+{
+	ARG_UNUSED(test);
+	ARG_UNUSED(fixture);
+
+	RESET_FAKE(gpio_fake_pin_configure);
+#ifdef CONFIG_GPIO_GET_CONFIG
+	RESET_FAKE(gpio_fake_pin_get_config);
+#endif
+	RESET_FAKE(gpio_fake_port_get_raw);
+	RESET_FAKE(gpio_fake_port_set_masked_raw);
+	RESET_FAKE(gpio_fake_port_set_bits_raw);
+	RESET_FAKE(gpio_fake_port_clear_bits_raw);
+	RESET_FAKE(gpio_fake_port_toggle_bits);
+	RESET_FAKE(gpio_fake_pin_interrupt_configure);
+	RESET_FAKE(gpio_fake_manage_callback);
+	RESET_FAKE(gpio_fake_get_pending_int);
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	RESET_FAKE(gpio_fake_port_get_direction);
+#endif
+}
+
+ZTEST_RULE(gpio_fake_reset_rule, gpio_fake_reset_rule_before, NULL);
+#endif /* CONFIG_ZTEST */
+
+static DEVICE_API(gpio, gpio_fake_driver) = {
+	.pin_configure = gpio_fake_pin_configure,
+#ifdef CONFIG_GPIO_GET_CONFIG
+	.pin_get_config = gpio_fake_pin_get_config,
+#endif
+	.port_get_raw = gpio_fake_port_get_raw,
+	.port_set_masked_raw = gpio_fake_port_set_masked_raw,
+	.port_set_bits_raw = gpio_fake_port_set_bits_raw,
+	.port_clear_bits_raw = gpio_fake_port_clear_bits_raw,
+	.port_toggle_bits = gpio_fake_port_toggle_bits,
+	.pin_interrupt_configure = gpio_fake_pin_interrupt_configure,
+	.manage_callback = gpio_fake_manage_callback,
+	.get_pending_int = gpio_fake_get_pending_int,
+#ifdef CONFIG_GPIO_GET_DIRECTION
+	.port_get_direction = gpio_fake_port_get_direction,
+#endif /* CONFIG_GPIO_GET_DIRECTION */
+};
+
+#define DEFINE_GPIO_FAKE(_num)                                                                     \
+                                                                                                   \
+	static struct gpio_fake_config gpio_fake_config##_num = {                                  \
+		.port_pin_mask = 0xffffffff,                                                       \
+	};                                                                                         \
+	static struct gpio_driver_data gpio_fake_data##_num;                                       \
+	DEVICE_DT_INST_DEFINE(_num, NULL, PM_DEVICE_DT_INST_GET(_num), &gpio_fake_data##_num,      \
+			      &gpio_fake_config##_num, POST_KERNEL, CONFIG_GPIO_INIT_PRIORITY,     \
+			      &gpio_fake_driver);
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_GPIO_FAKE)

--- a/dts/bindings/gpio/zephyr,gpio-fake.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-fake.yaml
@@ -1,0 +1,16 @@
+# Copyright 2025, Alexandre Bailon
+# SPDX-License-Identifier: Apache-2.0
+
+description: Fake GPIO
+
+compatible: "zephyr,gpio-fake"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+  "#gpio-cells":
+    const: 2
+
+gpio-cells:
+  - pin
+  - flags

--- a/include/zephyr/drivers/gpio/gpio_fake.h
+++ b/include/zephyr/drivers/gpio/gpio_fake.h
@@ -1,0 +1,39 @@
+
+#ifndef ZEPHYR_GPIO_FAKE_H
+#define ZEPHYR_GPIO_FAKE_H
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/fff.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_pin_configure, const struct device *, gpio_pin_t,
+			gpio_flags_t);
+#ifdef CONFIG_GPIO_GET_CONFIG
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_pin_get_config, const struct device *, gpio_pin_t,
+			gpio_flags_t *);
+#endif
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_get_raw, const struct device *, gpio_port_value_t *);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_set_masked_raw, const struct device *, gpio_port_pins_t,
+			gpio_port_value_t);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_set_bits_raw, const struct device *, gpio_port_pins_t);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_clear_bits_raw, const struct device *,
+			gpio_port_pins_t);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_toggle_bits, const struct device *, gpio_port_pins_t);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_pin_interrupt_configure, const struct device *, gpio_pin_t,
+			enum gpio_int_mode, enum gpio_int_trig);
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_manage_callback, const struct device *,
+			struct gpio_callback *, bool);
+DECLARE_FAKE_VALUE_FUNC(uint32_t, gpio_fake_get_pending_int, const struct device *);
+#ifdef CONFIG_GPIO_GET_DIRECTION
+DECLARE_FAKE_VALUE_FUNC(int, gpio_fake_port_get_direction, gpio_port_pins_t, gpio_port_pins_t *,
+			gpio_port_pins_t *);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_GPIO_FAKE_H */


### PR DESCRIPTION
To test the switch hbridge component, we have to validate the state of two gpios and their state for a pperiod of time.
This adds a GPIO fake driver which allows getting a history call of functions with the argument values.